### PR TITLE
chore: es6 all the things, avoid redundant publish

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,13 @@ module.exports = {
       "warn",
       "global"
     ],
-    "no-var": "off",
-    "prefer-const": "off",
+    "no-var": "error",
+    "prefer-const": "error",
     "semi": [
       "error",
       "always"
     ],
+    "prefer-arrow-callback": "error",
     "no-caller": "error",
     "no-undef": "error",
     "no-unused-vars": "error",

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -43,10 +43,6 @@ const Deferred = require("./Deferred");
  */
 class Pool {
   constructor(factory) {
-    if (!(this instanceof Pool)) {
-      return new Pool(factory);
-    }
-
     if (!factory.create) {
       throw new Error("create function is required");
     }
@@ -148,12 +144,12 @@ class Pool {
    * @private
    */
   _removeIdle() {
-    var toRemove = [];
-    var now = Date.now();
-    var i;
-    var available = this._availableObjects.length;
-    var maxRemovable = this._count - this._factory.min;
-    var timeout;
+    const toRemove = [];
+    const now = Date.now();
+    let i;
+    let available = this._availableObjects.length;
+    const maxRemovable = this._count - this._factory.min;
+    let timeout;
 
     this._removeIdleScheduled = false;
 
@@ -212,8 +208,8 @@ class Pool {
    * @private
    */
   _dispense() {
-    var resourceWithTimeout = null;
-    var waitingCount = this._pendingAcquires.length;
+    let resourceWithTimeout = null;
+    const waitingCount = this._pendingAcquires.length;
 
     this._log(
       `dispense() clients=${waitingCount} available=${
@@ -286,7 +282,7 @@ class Pool {
   }
 
   _addResourceToAvailableObjects(resource) {
-    var resourceWithTimeout = {
+    const resourceWithTimeout = {
       resource: resource,
       timeout: Date.now() + this._factory.idleTimeoutMillis
     };
@@ -300,7 +296,7 @@ class Pool {
    * @private
    */
   _ensureMinimum() {
-    var i, diff;
+    let i, diff;
     if (!this._draining && this._count < this._factory.min) {
       diff = this._factory.min - this._count;
       for (i = 0; i < diff; i++) {
@@ -362,7 +358,7 @@ class Pool {
     }
 
     // check to see if this object exists in the `in use` list and remove it
-    var index = this._inUseObjects.indexOf(resource);
+    const index = this._inUseObjects.indexOf(resource);
     if (index < 0) {
       this._log(
         "attempt to release an invalid resource: " + new Error().stack,
@@ -411,7 +407,7 @@ class Pool {
     // disable the ability to put more work on the queue.
     this._draining = true;
 
-    var check = callback => {
+    const check = callback => {
       // wait until all client requests have been satisfied.
       if (this._pendingAcquires.length > 0) {
         // pool is draining so we wont accept new acquires but
@@ -450,9 +446,9 @@ class Pool {
   destroyAllNow() {
     this._log("force destroying all objects", "info");
 
-    var willDie = this._availableObjects;
+    const willDie = this._availableObjects;
     this._availableObjects = [];
-    var todo = willDie.length;
+    const todo = willDie.length;
 
     this._removeIdleScheduled = false;
     clearTimeout(this._removeIdleTimer);
@@ -462,8 +458,8 @@ class Pool {
         return callback();
       }
 
-      var resource;
-      var done = 0;
+      let resource;
+      let done = 0;
 
       while ((resource = willDie.shift())) {
         this.destroy(resource.resource);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "http://github.com/sushantdhiman/sequelize-pool.git"
   },
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "bluebird": "^3.5.2"
   },

--- a/test/integration/config-test.js
+++ b/test/integration/config-test.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var tap = require("tap");
-var Pool = require("../..").Pool;
+const tap = require("tap");
+const Pool = require("../..").Pool;
 
-tap.test("fail for max < min", function(t) {
-  var factory = {
+tap.test("fail for max < min", t => {
+  const factory = {
     name: "test-config",
     create: () => {},
     destroy: () => {},
@@ -19,8 +19,8 @@ tap.test("fail for max < min", function(t) {
   t.end();
 });
 
-tap.test("fail without factory.create", function(t) {
-  var factory = {
+tap.test("fail without factory.create", t => {
+  const factory = {
     name: "test-config",
     destroy: () => {},
     validate: () => {},
@@ -34,8 +34,8 @@ tap.test("fail without factory.create", function(t) {
   t.end();
 });
 
-tap.test("fail without factory.destroy", function(t) {
-  var factory = {
+tap.test("fail without factory.destroy", t => {
+  const factory = {
     name: "test-config",
     create: () => {},
     validate: () => {},
@@ -49,8 +49,8 @@ tap.test("fail without factory.destroy", function(t) {
   t.end();
 });
 
-tap.test("fail without factory.validate", function(t) {
-  var factory = {
+tap.test("fail without factory.validate", t => {
+  const factory = {
     name: "test-config",
     create: () => {},
     destroy: () => {},

--- a/test/integration/create-test.js
+++ b/test/integration/create-test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var tap = require("tap");
-var Promise = require("bluebird");
-var Pool = require("../..").Pool;
+const tap = require("tap");
+const Promise = require("bluebird");
+const Pool = require("../..").Pool;
 
-tap.test("factory.create", function(t) {
-  tap.test("handle creation errors", function(t) {
-    var created = 0;
-    var pool = new Pool({
+tap.test("factory.create", t => {
+  tap.test("handle creation errors", t => {
+    let created = 0;
+    const pool = new Pool({
       name: "test-create-errors",
       create: function() {
         if (created++ < 5) {
@@ -26,7 +26,7 @@ tap.test("factory.create", function(t) {
     const tests = [];
 
     // ensure that creation errors do not populate the pool.
-    for (var i = 1; i <= 5; i++) {
+    for (let i = 1; i <= 5; i++) {
       tests.push(t.rejects(pool.acquire(), new Error(`Error ${i} occurred.`)));
     }
 
@@ -40,9 +40,9 @@ tap.test("factory.create", function(t) {
       .catch(t.threw);
   });
 
-  tap.test("handle creation errors from delayed creates", function(t) {
-    var created = 0;
-    var pool = new Pool({
+  tap.test("handle creation errors from delayed creates", t => {
+    let created = 0;
+    const pool = new Pool({
       name: "test-async-create-errors",
       create: function() {
         if (created++ < 5) {
@@ -67,7 +67,7 @@ tap.test("factory.create", function(t) {
     const tests = [];
 
     // ensure that creation errors do not populate the pool.
-    for (var i = 0; i < 5; i++) {
+    for (let i = 0; i < 5; i++) {
       tests.push(t.rejects(pool.acquire(), new Error(`Error occurred.`)));
     }
 

--- a/test/integration/getters-test.js
+++ b/test/integration/getters-test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var tap = require("tap");
-var Promise = require("bluebird");
-var Pool = require("../..").Pool;
-var random = () => Math.floor(Math.random() * 1000);
+const tap = require("tap");
+const Promise = require("bluebird");
+const Pool = require("../..").Pool;
+const random = () => Math.floor(Math.random() * 1000);
 
-tap.test("pool.name", function(t) {
-  var pool = new Pool({
+tap.test("pool.name", t => {
+  const pool = new Pool({
     name: "test-pool.name",
     create: () => Promise.resolve({ id: random() }),
     destroy: () => {},
@@ -19,8 +19,8 @@ tap.test("pool.name", function(t) {
   t.end();
 });
 
-tap.test("pool.size", function(t) {
-  var pool = new Pool({
+tap.test("pool.size", t => {
+  const pool = new Pool({
     name: "test-pool.size",
     create: () => Promise.resolve({ id: random() }),
     destroy: () => {},
@@ -54,8 +54,8 @@ tap.test("pool.size", function(t) {
     .catch(t.threw);
 });
 
-tap.test("pool.available", function(t) {
-  var pool = new Pool({
+tap.test("pool.available", t => {
+  const pool = new Pool({
     name: "test-pool.available",
     create: () => Promise.resolve({ id: random() }),
     destroy: () => {},

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var tap = require("tap");
-var Pool = require("../..").Pool;
-var utils = require("../utils");
-var Promise = require("bluebird");
-var ResourceFactory = utils.ResourceFactory;
+const tap = require("tap");
+const Pool = require("../..").Pool;
+const utils = require("../utils");
+const Promise = require("bluebird");
+const ResourceFactory = utils.ResourceFactory;
 
-tap.test("pool expands only to max limit", function(t) {
-  var resourceFactory = new ResourceFactory();
+tap.test("pool expands only to max limit", t => {
+  const resourceFactory = new ResourceFactory();
 
-  var factory = {
+  const factory = {
     name: "test1",
     create: resourceFactory.create.bind(resourceFactory),
     destroy: resourceFactory.destroy.bind(resourceFactory),
@@ -20,7 +20,7 @@ tap.test("pool expands only to max limit", function(t) {
     acquireTimeoutMillis: 100
   };
 
-  var pool = new Pool(factory);
+  const pool = new Pool(factory);
 
   pool
     .acquire()
@@ -35,10 +35,10 @@ tap.test("pool expands only to max limit", function(t) {
     .catch(t.threw);
 });
 
-tap.test("removes correct object on reap", function(t) {
-  var resourceFactory = new ResourceFactory();
+tap.test("removes correct object on reap", t => {
+  const resourceFactory = new ResourceFactory();
 
-  var pool = new Pool({
+  const pool = new Pool({
     name: "test3",
     create: resourceFactory.create.bind(resourceFactory),
     destroy: resourceFactory.destroy.bind(resourceFactory),
@@ -49,7 +49,7 @@ tap.test("removes correct object on reap", function(t) {
 
   pool.acquire().then(client => {
     // should be removed second
-    setTimeout(function() {
+    setTimeout(() => {
       pool.destroy(client);
     }, 5);
   });
@@ -59,20 +59,20 @@ tap.test("removes correct object on reap", function(t) {
     pool.destroy(client);
   });
 
-  setTimeout(function() {
+  setTimeout(() => {
     t.equal(1, resourceFactory.bin[0].id);
     t.equal(0, resourceFactory.bin[1].id);
     t.end();
   }, 100);
 });
 
-tap.test("drains", function(t) {
-  var count = 5;
-  var acquired = 0;
+tap.test("drains", t => {
+  const count = 5;
+  let acquired = 0;
 
-  var resourceFactory = new ResourceFactory();
+  const resourceFactory = new ResourceFactory();
 
-  var pool = new Pool({
+  const pool = new Pool({
     name: "test4",
     create: resourceFactory.create.bind(resourceFactory),
     destroy: resourceFactory.destroy.bind(resourceFactory),
@@ -83,7 +83,7 @@ tap.test("drains", function(t) {
   });
 
   // request 5 resources that release after 250ms
-  for (var i = 0; i < count; i++) {
+  for (let i = 0; i < count; i++) {
     pool.acquire().then(client => {
       acquired += 1;
       t.equal(typeof client.id, "number");
@@ -113,12 +113,12 @@ tap.test("drains", function(t) {
     .catch(t.threw);
 });
 
-tap.test("logging", function(t) {
-  var logLevels = { verbose: 0, info: 1, warn: 2, error: 3 };
-  var logMessages = { verbose: [], info: [], warn: [], error: [] };
-  var resourceFactory = new ResourceFactory();
+tap.test("logging", t => {
+  const logLevels = { verbose: 0, info: 1, warn: 2, error: 3 };
+  const logMessages = { verbose: [], info: [], warn: [], error: [] };
+  const resourceFactory = new ResourceFactory();
 
-  var factory = {
+  const factory = {
     name: "test12",
     create: resourceFactory.create.bind(resourceFactory),
     destroy: () => {},
@@ -130,13 +130,13 @@ tap.test("logging", function(t) {
       testlog(msg, level);
     }
   };
-  var testlog = function(msg, level) {
+  const testlog = function(msg, level) {
     t.ok(level in logLevels);
     logMessages[level].push(msg);
   };
 
-  var pool = new Pool(factory);
-  var pool2 = new Pool({
+  const pool = new Pool(factory);
+  const pool2 = new Pool({
     name: "testNoLog",
     create: resourceFactory.create.bind(resourceFactory),
     destroy: () => {},
@@ -161,9 +161,9 @@ tap.test("logging", function(t) {
     .catch(t.threw);
 });
 
-tap.test("removes from available objects on destroy", function(t) {
-  var destroyCalled = false;
-  var factory = {
+tap.test("removes from available objects on destroy", t => {
+  let destroyCalled = false;
+  const factory = {
     name: "test13",
     create: function() {
       return Promise.resolve({});
@@ -177,7 +177,7 @@ tap.test("removes from available objects on destroy", function(t) {
     idleTimeoutMillis: 100
   };
 
-  var pool = new Pool(factory);
+  const pool = new Pool(factory);
 
   pool
     .acquire()
@@ -193,13 +193,13 @@ tap.test("removes from available objects on destroy", function(t) {
     });
 });
 
-tap.test("removes from available objects on validation failure", function(t) {
-  var destroyCalled = 0;
-  var validateCalled = 0;
-  var destroyedClient = null;
-  var count = 0;
+tap.test("removes from available objects on validation failure", t => {
+  let destroyCalled = 0;
+  let validateCalled = 0;
+  let destroyedClient = null;
+  let count = 0;
 
-  var factory = {
+  const factory = {
     name: "test14",
     create: () => {
       return Promise.resolve({ count: count++ });
@@ -217,7 +217,7 @@ tap.test("removes from available objects on validation failure", function(t) {
     idleTimeoutMillis: 100
   };
 
-  var pool = new Pool(factory);
+  const pool = new Pool(factory);
 
   pool
     .acquire()
@@ -242,10 +242,10 @@ tap.test("removes from available objects on validation failure", function(t) {
     .catch(t.threw);
 });
 
-tap.test("acquire resolves after some failures", function(t) {
-  var rejected = 0;
+tap.test("acquire resolves after some failures", t => {
+  let rejected = 0;
 
-  var factory = {
+  const factory = {
     name: "test16",
     create: function() {
       rejected++;
@@ -262,7 +262,7 @@ tap.test("acquire resolves after some failures", function(t) {
     min: 0
   };
 
-  var pool = new Pool(factory);
+  const pool = new Pool(factory);
 
   Promise.resolve()
     .then(() => t.rejects(pool.acquire(), new Error("Create error")))
@@ -275,8 +275,8 @@ tap.test("acquire resolves after some failures", function(t) {
     .catch(t.threw);
 });
 
-tap.test("returns only valid object to the pool", function(t) {
-  var pool = new Pool({
+tap.test("returns only valid object to the pool", t => {
+  const pool = new Pool({
     name: "test17",
     create: function() {
       return Promise.delay(1).then(() => ({ id: "validId" }));

--- a/test/stress/async-test.js
+++ b/test/stress/async-test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var tap = require("tap");
-var Pool = require("../..").Pool;
-var Promise = require("bluebird");
+const tap = require("tap");
+const Pool = require("../..").Pool;
+const Promise = require("bluebird");
 
-tap.test("async multiple calls", function(t) {
-  var createCount = 0;
+tap.test("async multiple calls", t => {
+  let createCount = 0;
 
-  var pool = new Pool({
+  const pool = new Pool({
     name: "test",
     create: function() {
       return Promise.delay(50).then(() => {
@@ -23,9 +23,9 @@ tap.test("async multiple calls", function(t) {
     log: false
   });
 
-  var borrowedObjects = [];
+  const borrowedObjects = [];
 
-  var acquireRelease = function(
+  const acquireRelease = function(
     num,
     inUseCount,
     availableCount,
@@ -36,7 +36,7 @@ tap.test("async multiple calls", function(t) {
     availableCount = availableCount === undefined ? 0 : availableCount;
 
     //console.log("Request " + num + " - available " + pool.available);
-    return pool.acquire().then(function(obj) {
+    return pool.acquire().then(obj => {
       // check we haven't already borrowed this before:
       t.equal(
         borrowedObjects.indexOf(obj),
@@ -49,7 +49,7 @@ tap.test("async multiple calls", function(t) {
       t.ok(createCount <= 3);
 
       return Promise.delay(releaseTimeout).then(() => {
-        var pos = borrowedObjects.indexOf(obj);
+        const pos = borrowedObjects.indexOf(obj);
         borrowedObjects.splice(pos, 1);
 
         //console.log("Release " + num + " - object id:", obj.id);

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Promise = require("bluebird");
+const Promise = require("bluebird");
 
 /**
  * Generic class for handling creation of resources


### PR DESCRIPTION
As a sitenote: Sequelize(v5) no longers ships duplicate dependencies 🎉 

I noticed however that this package ships tests and stuff so I figured I could fix that.
I also let `eslint` auto fix all the let/const/arrow conversion.
Lastly: The `if(this instanceof ...` check is redundant with es6 because class ctors cannot be invoked with new (will error).