### PR TITLE
make destroy() call its' side-effects once

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -381,6 +381,15 @@ class Pool {
    * @returns {void}
    */
   destroy(resource) {
+    if (resource.destroyed_at) {
+      this._log(
+          "Calling destroy on an already destroyed resource",
+          "error"
+      );
+      return;
+    }
+    resource.destroyed_at = new Date()
+    
     this._count -= 1;
     if (this._count < 0) this._count = 0;
 


### PR DESCRIPTION
multiple calls to destroy will only result in its' side effects being called once.
this is a fix for https://github.com/sequelize/sequelize/issues/10902