### PR TITLE
#7 releasing  all connections on destroyAllNow

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -464,14 +464,21 @@ class Pool {
   destroyAllNow() {
     this._log("force destroying all objects", "info");
 
+    const willDie = this._availableObjects;
+
     this._removeIdleScheduled = false;
     clearTimeout(this._removeIdleTimer);
 
     return Promise.all(
-      this._availableObjects.map(resource => {
+      willDie.map(resource => {
         return this.destroy(resource.resource);
       })
-    ).then(() => (this._availableObjects = []));
+    ).then(
+      () =>
+        (this._availableObjects = this._availableObjects.filter(
+          it => !willDie.includes(it)
+        ))
+    );
   }
 }
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -403,14 +403,11 @@ class Pool {
     this._count -= 1;
     if (this._count < 0) this._count = 0;
 
-    const destroyResult = this._factory.destroy(resource);
-
-    const thenable =
-      (destroyResult && destroyResult.then) || Promise.resolve(destroyResult);
-
-    // _ensureMinimum should also be converted into a thenable, calling multiple times in a loop to
+    // _ensureMinimum should also be promisifed, calling multiple times in a loop to
     // a very likely asynchrounous operation might have undesired side effects if not taken into account
-    return thenable.then(() => this._ensureMinimum());
+    return Promise.resolve(this._factory.destroy(resource)).then(() =>
+      this._ensureMinimum()
+    );
   }
 
   /**
@@ -470,9 +467,7 @@ class Pool {
     clearTimeout(this._removeIdleTimer);
 
     return Promise.all(
-      willDie.map(resource => {
-        return this.destroy(resource.resource);
-      })
+      willDie.map(resource => this.destroy(resource.resource))
     ).then(
       () =>
         (this._availableObjects = this._availableObjects.filter(

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -403,8 +403,14 @@ class Pool {
     this._count -= 1;
     if (this._count < 0) this._count = 0;
 
-    this._factory.destroy(resource);
-    this._ensureMinimum();
+    const destroyResult = this._factory.destroy(resource);
+
+    const thenable =
+      (destroyResult && destroyResult.then) || Promise.resolve(destroyResult);
+
+    // _ensureMinimum should also be converted into a thenable, calling multiple times in a loop to
+    // a very likely asynchrounous operation might have undesired side effects if not taken into account
+    return thenable.then(() => this._ensureMinimum());
   }
 
   /**
@@ -458,30 +464,14 @@ class Pool {
   destroyAllNow() {
     this._log("force destroying all objects", "info");
 
-    const willDie = this._availableObjects;
-    this._availableObjects = [];
-    const todo = willDie.length;
-
     this._removeIdleScheduled = false;
     clearTimeout(this._removeIdleTimer);
 
-    return new Promise(resolve => {
-      if (todo === 0) {
-        return resolve();
-      }
-
-      let resource;
-      let done = 0;
-
-      while ((resource = willDie.shift())) {
-        this.destroy(resource.resource);
-        ++done;
-
-        if (done === todo && resolve) {
-          return resolve();
-        }
-      }
-    });
+    return Promise.all(
+      this._availableObjects.map(resource => {
+        return this.destroy(resource.resource);
+      })
+    ).then(() => (this._availableObjects = []));
   }
 }
 


### PR DESCRIPTION
Fix for #7 tackling down the root problem: `this._availableObjects` variable was being emptied before the connections were actually released resulting in an inconsistency at runtime; by the time `  destroy(resource)` was called, connections were still active but the reference in memory was already lost.