### PR TITLE
Ensure pool uses existing client on a LIFO basis

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -198,7 +198,7 @@ class Pool {
   /**
    * Try to get a new client to work, and clean up pool unused (idle) items.
    *
-   *  - If there are available clients waiting, shift the first one out (LIFO),
+   *  - If there are available clients waiting, pop the first one out (LIFO),
    *    and call its callback.
    *  - If there are no waiting clients, try to create one if it won't exceed
    *    the maximum number of clients.
@@ -221,13 +221,15 @@ class Pool {
 
     while (this._availableObjects.length > 0) {
       this._log("dispense() - reusing obj", "verbose");
-      resourceWithTimeout = this._availableObjects[0];
+      resourceWithTimeout = this._availableObjects[
+        this._availableObjects.length - 1
+      ];
       if (!this._factory.validate(resourceWithTimeout.resource)) {
         this.destroy(resourceWithTimeout.resource);
         continue;
       }
 
-      this._availableObjects.shift();
+      this._availableObjects.pop();
       this._inUseObjects.push(resourceWithTimeout.resource);
 
       const deferred = this._pendingAcquires.shift();

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -33,6 +33,35 @@ tap.test("pool expands only to max limit", t => {
     .catch(t.threw);
 });
 
+tap.test("pool uses LIFO", t => {
+  const resourceFactory = new ResourceFactory();
+
+  const factory = {
+    name: "test1",
+    create: resourceFactory.create.bind(resourceFactory),
+    destroy: resourceFactory.destroy.bind(resourceFactory),
+    validate: resourceFactory.validate.bind(resourceFactory),
+    max: 2,
+    min: 0,
+    idleTimeoutMillis: 100,
+    acquireTimeoutMillis: 100
+  };
+
+  const pool = new Pool(factory);
+
+  pool.acquire().then(clientA => {
+    pool.acquire().then(clientB => {
+      pool.release(clientA);
+      pool.release(clientB);
+
+      pool.acquire().then(clientC => {
+        t.equal(clientB, clientC);
+        t.end();
+      });
+    });
+  });
+});
+
 tap.test("removes correct object on reap", t => {
   const resourceFactory = new ResourceFactory();
 


### PR DESCRIPTION
The documentation claimed that the pool was LIFO, but in practice it was not. I suspect this is the reason the pool grows more than required, as clients are constantly cycled through, and thus never reaches their idle time, unless usage essentially stops.

This should fix https://github.com/sequelize/sequelize/issues/10907 and the original report in https://github.com/sequelize/sequelize/issues/10902.