### PR TITLE
destroy returns a Promise

### DIFF
--- a/src/AggregateError.ts
+++ b/src/AggregateError.ts
@@ -1,0 +1,25 @@
+/**
+ * A wrapper for multiple Errors
+ */
+export class AggregateError extends Error {
+  errors: Error[];
+
+  constructor(errors: Error[]) {
+    super();
+    this.errors = errors;
+    this.name = 'AggregateError';
+  }
+
+  toString(): string {
+    const message = `AggregateError of:\n${this.errors
+      .map((error) =>
+        error === this
+          ? '[Circular AggregateError]'
+          : error instanceof AggregateError
+          ? String(error).replace(/\n$/, '').replace(/^/gm, '  ')
+          : String(error).replace(/^/gm, '    ').substring(2)
+      )
+      .join('\n')}\n`;
+    return message;
+  }
+}

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -594,6 +594,6 @@ export class Pool<RawResource> {
       this._availableObjects.map((resource) => {
         return this.destroy(resource.resource);
       })
-    ).then(() => {});
+    ).then(() => {}); //eslint-disable-line @typescript-eslint/no-empty-function
   }
 }

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -218,6 +218,41 @@ tap.test('removes from available objects on destroy', (t) => {
     });
 });
 
+tap.test('waits on destroy promise on destroy', (t) => {
+  let destroyResolved = false;
+  const factory = {
+    name: 'test13',
+    create: function () {
+      return Promise.resolve({});
+    },
+    destroy: function () {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          destroyResolved = true;
+          resolve();
+        }, 100);
+      });
+    },
+    validate: () => {},
+    max: 2,
+    min: 0,
+    idleTimeoutMillis: 100,
+  };
+
+  const pool = new Pool(factory);
+
+  pool
+    .acquire()
+    .then((obj) => pool.destroy(obj))
+    .then(() => {
+      t.equal(destroyResolved, true);
+      t.equal(pool.available, 0);
+      t.equal(pool.using, 0);
+      t.equal(pool.waiting, 0);
+      t.end();
+    });
+});
+
 tap.test(
   'decrement _count only when resource is actually removed from queues',
   (t) => {


### PR DESCRIPTION
in Sequelize the [destroy](https://github.com/sequelize/sequelize/blob/6e0b13762bfdeac80b3acd580e75f68985c211bd/lib/dialects/abstract/connection-manager.js#L131) function returns a promise that is not awaited by sequelize-pool.

When calling `await sequelize.close()` it will now wait for the destroy function's promise to resolve.

```js
const sequelize = new Sequelize(..., {
	...
	hooks: {
		beforeDisconnect: (connection) => {
			console.log("before disconnect")
		},
		afterDisconnect: (connection) => {
			console.log("after disconnect")
		},
	},
});
... do some stuff with sequelize
console.log("before close")
await sequelize.close()
console.log("after close")
```

### without this PR

1. log "before close"
2. log "before disconnect"
3. log "after close"
4. disconnect
5. log "after disconnect"

### with this PR

1. log "before close"
2. log "before disconnect"
3. disconnect
4. log "after disconnect"
5. log "after close"