### PR TITLE
Add maxUses option to the pooler

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ var pool = new Pool({
     idleTimeoutMillis : 30000,
     // Delay in milliseconds after which pending acquire request in the pool will be rejected.
     acquireTimeoutMillis: 30000,
+    // optional. if you set this, the resource will be destroyed and replaced after it has been used
+    // `maxUses` number of times, which can help with re-balancing when pool members are added after
+    // the process has started and already filled the pool with healthy connections.
+    maxUses  : 1000,
      // Function, defaults to console.log
     log : true
 });

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ var pool = new Pool({
     acquireTimeoutMillis: 30000,
     // optional. if you set this, the resource will be destroyed and replaced after it has been used
     // `maxUses` number of times, which can help with re-balancing when pool members are added after
-    // the process has started and already filled the pool with healthy connections.
-    maxUses  : 1000,
+    // the process has started and already filled the pool with healthy connections.  See below for details.
+    maxUses  : 7200,
      // Function, defaults to console.log
     log : true
 });
@@ -127,6 +127,35 @@ pool.maxSize
 pool.minSize
 
 ```
+
+# About maxUses
+
+Imagine a scenario where you have 10 app servers (hosting an API) that each connect to a read-replica set of 3 members, accessible behind a DNS name that round-robins IPs for the 3 replicas.  Each app server rus a connection pool of 25 connections.
+
+You start your app servers with an ambient traffic load of 50 http requests per second, and the connection pools likely fill up in a minute or two.  Everything is great at this point.
+
+But when you hit weekly traffic peaks, you might reach up to 1,000 http requests per second.  If you have a DB with elastic read replicas, you might quickly add 10 more read replicas during this peak time and scale them back down during slower times of the week in order to reduce cost and avoid the additional replication lag you might see with larger numbers or read replicas.
+
+When you add these 10 read replicas, assuming the first 3 remain healthy, the connection pool with not inherently adopt these new replicas because the pools are full and the connections are healthy, so connections are continuously reused with no need to create new ones.  Some level of intervention is needed to fill the connection pool with connections that are balanced between all the replicas.
+
+If you set the `maxUses` configuration option, the pool will proactively retire a resource (connection) once it has been acquired and released `maxUses` number of times, which over a period of time will eventually lead to a relatively balanced pool.
+
+One way to calculate a reasonable value for `maxUses` is to identify an acceptable window for rebalancing and then solve for `maxUses`:
+
+```
+maxUses = rebalanceWindowSeconds * totalRequestsPerSecond / numAppInstances / poolSize
+```
+
+In the example above, assuming we acquire and release 1 connection per request and we are aiming for a 30 minute rebalancing window:
+
+```
+maxUses = rebalanceWindowSeconds * totalRequestsPerSecond / numAppInstances / poolSize
+   7200 =        1800            *          1000          /        10       /    25
+```
+
+...in other words we would retire and replace a connection after every 7200 uses, which we expect to be around 30 minutes under peak load.
+
+Of course, you'll want to test scenarios for your own application since every app and every traffic pattern is different.
 
 ## Run Tests
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -28,6 +28,13 @@ const Deferred = require("./Deferred");
  *   When the pool is created, or a resource destroyed, this minimum will
  *   be checked. If the pool resource count is below the minimum, a new
  *   resource will be created and added to the pool.
+ * @param {Number} [factory.maxUses=0]
+ *   The number of times an item is to be used before it is destroyed
+ *   no matter whether it is still healthy.  A value of 0 indicates the
+ *   item should be used indefinitely so long as it is healthy.
+ *   This can help with "re-balancing" connections when pool members behind
+ *   a load balancer are added but are not being adopted due to pools being
+ *   full of pre-existing persistent connections.
  * @param {Number} [factory.idleTimeoutMillis=30000]
  *   Delay in milliseconds after which available resources in the pool will be destroyed.
  *   This does not affects pending acquire requests.
@@ -74,6 +81,13 @@ class Pool {
       throw new Error("max is smaller than min");
     }
 
+    if (
+      factory.maxUses &&
+      (typeof factory.maxUses !== "number" || factory.maxUses < 0)
+    ) {
+      throw new Error("maxUses must be an integer >= 0");
+    }
+
     // defaults
     factory.idleTimeoutMillis = factory.idleTimeoutMillis || 30000;
     factory.acquireTimeoutMillis = factory.acquireTimeoutMillis || 30000;
@@ -81,10 +95,12 @@ class Pool {
     factory.max = parseInt(factory.max, 10);
     factory.min = parseInt(factory.min, 10);
     factory.log = factory.log || false;
+    factory.maxUses = factory.maxUses || 0;
 
     this._factory = factory;
     this._count = 0;
     this._draining = false;
+    this._maxUsesPerResource = factory.maxUses;
 
     // queues
     this._pendingAcquires = [];
@@ -207,7 +223,7 @@ class Pool {
    * @private
    */
   _dispense() {
-    let resourceWithTimeout = null;
+    let wrappedResource = null;
     const waitingCount = this._pendingAcquires.length;
 
     this._log(
@@ -221,19 +237,22 @@ class Pool {
 
     while (this._availableObjects.length > 0) {
       this._log("dispense() - reusing obj", "verbose");
-      resourceWithTimeout = this._availableObjects[
+      wrappedResource = this._availableObjects[
         this._availableObjects.length - 1
       ];
-      if (!this._factory.validate(resourceWithTimeout.resource)) {
-        this.destroy(resourceWithTimeout.resource);
+      if (!this._factory.validate(wrappedResource.resource)) {
+        this.destroy(wrappedResource.resource);
         continue;
       }
 
       this._availableObjects.pop();
-      this._inUseObjects.push(resourceWithTimeout.resource);
+      this._addResourceToInUseObjects(
+        wrappedResource.resource,
+        wrappedResource.useCount
+      );
 
       const deferred = this._pendingAcquires.shift();
-      return deferred.resolve(resourceWithTimeout.resource);
+      return deferred.resolve(wrappedResource.resource);
     }
 
     if (this._count < this._factory.max) {
@@ -257,10 +276,10 @@ class Pool {
         const deferred = this._pendingAcquires.shift();
 
         if (deferred) {
-          this._inUseObjects.push(resource);
+          this._addResourceToInUseObjects(resource, 0);
           deferred.resolve(resource);
         } else {
-          this._addResourceToAvailableObjects(resource);
+          this._addResourceToAvailableObjects(resource, 0);
         }
       })
       .catch(error => {
@@ -277,15 +296,24 @@ class Pool {
       });
   }
 
-  _addResourceToAvailableObjects(resource) {
-    const resourceWithTimeout = {
+  _addResourceToAvailableObjects(resource, useCount) {
+    const wrappedResource = {
       resource: resource,
+      useCount: useCount,
       timeout: Date.now() + this._factory.idleTimeoutMillis
     };
 
-    this._availableObjects.push(resourceWithTimeout);
+    this._availableObjects.push(wrappedResource);
     this._dispense();
     this._scheduleRemoveIdle();
+  }
+
+  _addResourceToInUseObjects(resource, useCount) {
+    const wrappedResource = {
+      resource: resource,
+      useCount: useCount
+    };
+    this._inUseObjects.push(wrappedResource);
   }
 
   /**
@@ -354,7 +382,9 @@ class Pool {
     }
 
     // check to see if this object exists in the `in use` list and remove it
-    const index = this._inUseObjects.indexOf(resource);
+    const index = this._inUseObjects.findIndex(
+      wrappedResource => wrappedResource.resource === resource
+    );
     if (index < 0) {
       this._log(
         "attempt to release an invalid resource: " + new Error().stack,
@@ -362,9 +392,29 @@ class Pool {
       );
       return;
     }
-
+    const wrappedResource = this._inUseObjects[index];
     this._inUseObjects.splice(index, 1);
-    this._addResourceToAvailableObjects(resource);
+    // Increment the useCount before adding it back to the available list
+    wrappedResource.useCount += 1;
+    this._addResourceToAvailableObjects(
+      wrappedResource.resource,
+      wrappedResource.useCount
+    );
+
+    if (
+      this._maxUsesPerResource > 0 &&
+      wrappedResource.useCount >= this._maxUsesPerResource
+    ) {
+      // Client reached the max use count, so go ahead and destroy it
+      this._log(
+        "release() destroying obj - useCount:" +
+          wrappedResource.useCount +
+          " maxUsesPerResource:" +
+          this._maxUsesPerResource,
+        "verbose"
+      );
+      this.destroy(wrappedResource.resource);
+    }
   }
 
   /**
@@ -385,7 +435,7 @@ class Pool {
       object => object.resource !== resource
     );
     this._inUseObjects = this._inUseObjects.filter(
-      object => object !== resource
+      object => object.resource !== resource
     );
 
     // resource was not removed, then no need to decrement _count

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -28,7 +28,7 @@ const Deferred = require("./Deferred");
  *   When the pool is created, or a resource destroyed, this minimum will
  *   be checked. If the pool resource count is below the minimum, a new
  *   resource will be created and added to the pool.
- * @param {Number} [factory.maxUses=0]
+ * @param {Number} [factory.maxUses=Infinity]
  *   The number of times an item is to be used before it is destroyed
  *   no matter whether it is still healthy.  A value of 0 indicates the
  *   item should be used indefinitely so long as it is healthy.
@@ -95,7 +95,7 @@ class Pool {
     factory.max = parseInt(factory.max, 10);
     factory.min = parseInt(factory.min, 10);
     factory.log = factory.log || false;
-    factory.maxUses = factory.maxUses || 0;
+    factory.maxUses = factory.maxUses || Infinity;
 
     this._factory = factory;
     this._count = 0;
@@ -401,10 +401,7 @@ class Pool {
       wrappedResource.useCount
     );
 
-    if (
-      this._maxUsesPerResource > 0 &&
-      wrappedResource.useCount >= this._maxUsesPerResource
-    ) {
+    if (wrappedResource.useCount >= this._maxUsesPerResource) {
       // Client reached the max use count, so go ahead and destroy it
       this._log(
         "release() destroying obj - useCount:" +

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -471,14 +471,12 @@ tap.test("pool destroys a resource when maxUses is reached", t => {
       pool.release(clientA);
 
       pool.acquire().then(clientC => {
+        // The third client should be new because the second was end-of-lifed
         t.notEqual(clientB, clientC);
+        // assert the first connection was destroyed once the max-use limit was reached
+        t.equal(0, resourceFactory.bin[0].id);
+        t.end();
       });
     });
   });
-
-  // assert the first connection was destroyed once the max-use limit was reached
-  setTimeout(() => {
-    t.equal(0, resourceFactory.bin[0].id);
-    t.end();
-  }, 100);
 });


### PR DESCRIPTION
My team has encountered a situation where new read replicas are not used when they have been added after the node process has already started and filled the connection pool with healthy connections.  This change offers a way to rebalance the load across a cluster by limiting the lifetime of a resource in the pool.

Once a resource has been used and released `maxUses` times, upon release the resource is destroyed rather than recycled.  Over a period of minutes or hours, depending on load volume and the `maxUses` config, connections will be "end-of-lifed" and replaced with new ones based on the balancing strategy used by the system (e.g. load balancer reverse proxy, DNS round-robin, etc.).

In essence, the change extends the pre-existing pattern of wrapping the resource with metadata when adding it to the availables list:  First it adds a `useCount` counter next to `timeout`, then it repeats the pattern for the in-use list so that the useCount metadata can be preserved across acquisitions and releases.

I appreciate your help reviewing this PR and hopefully adopting it, as it will greatly increase our ability to continue to grow with Sequelize.  Thank you!