### PR TITLE
Bug Fix:  Do not leak expired resources to pending requests

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -393,14 +393,9 @@ class Pool {
       return;
     }
     const wrappedResource = this._inUseObjects[index];
-    this._inUseObjects.splice(index, 1);
-    // Increment the useCount before adding it back to the available list
-    wrappedResource.useCount += 1;
-    this._addResourceToAvailableObjects(
-      wrappedResource.resource,
-      wrappedResource.useCount
-    );
 
+    // Increment the useCount before seeing if it can be added back to the available list
+    wrappedResource.useCount += 1;
     if (wrappedResource.useCount >= this._maxUsesPerResource) {
       // Client reached the max use count, so go ahead and destroy it
       this._log(
@@ -411,6 +406,14 @@ class Pool {
         "verbose"
       );
       this.destroy(wrappedResource.resource);
+      this._dispense();
+    } else {
+      // Move the resource from inUse to available
+      this._inUseObjects.splice(index, 1);
+      this._addResourceToAvailableObjects(
+        wrappedResource.resource,
+        wrappedResource.useCount
+      );
     }
   }
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -406,6 +406,9 @@ class Pool {
         "verbose"
       );
       this.destroy(wrappedResource.resource);
+      // Since we are not adding the resource back to the availables list, we need to go
+      // ahead and call _dispense() in order to ensure the resource replaced (if appropriate)
+      // and any pending resource requests are fulfilled.
       this._dispense();
     } else {
       // Move the resource from inUse to available

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -480,3 +480,34 @@ tap.test("pool destroys a resource when maxUses is reached", t => {
     });
   });
 });
+
+tap.test("pool destroys an expired without leaking to a pending request", t => {
+  const resourceFactory = new ResourceFactory();
+
+  const factory = {
+    name: "test21",
+    create: resourceFactory.create.bind(resourceFactory),
+    destroy: resourceFactory.destroy.bind(resourceFactory),
+    validate: resourceFactory.validate.bind(resourceFactory),
+    max: 1,
+    min: 0,
+    maxUses: 1,
+    idleTimeoutMillis: 100,
+    acquireTimeoutMillis: 100
+  };
+
+  const pool = new Pool(factory);
+
+  pool.acquire().then(clientA => {
+    // Queue an acquisition prior to releasing it...this request should get a
+    // brand new client (a bug in the original implementation of maxUses)
+    // caused the pending requests to get a connection that was about to be
+    // destroyed.
+    pool.acquire().then(clientB => {
+      t.notEqual(clientA, clientB);
+      pool.release(clientB);
+      t.end();
+    });
+    pool.release(clientA);
+  });
+});

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -481,7 +481,8 @@ tap.test("pool destroys a resource when maxUses is reached", t => {
   });
 });
 
-tap.test("pool destroys an expired without leaking to a pending request", t => {
+tap.test("pool does not leak expired resources to pending requests", t => {
+  // Built to test a bug fix introduced in https://github.com/sequelize/sequelize-pool/pull/18
   const resourceFactory = new ResourceFactory();
 
   const factory = {


### PR DESCRIPTION
Well, you asked for more contributions... :)

During scale out testing we noticed that every once in a while a resource was dispensed and then promptly closed.  I traced the issue back to a logic bug in my previous PR #18:  An expended connection would be placed into the available list, dispensed, then closed in the next tick while it was in use.

This PR fixes that issue by not placing expended resources back on the availables list and instead directly calling _dispense().

I added a unit test for the scenario, and we also confirmed improved behavior when testing a large scenario against AWS Aurora.

Thank you!