### PR TITLE
fix: respect min pool configuration

### DIFF
--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -442,6 +442,15 @@ export class Pool<RawResource> {
     this._pendingAcquires.push(deferred);
     this._dispense();
 
+    let i, diff;
+    if (this.size < this.minSize) {
+      diff = this.minSize - this.size;
+      for (i = 0; i < diff; i++) {
+        this._pendingAcquires.push(deferred);
+        this._dispense();
+      }
+    }
+
     return deferred.promise();
   }
 

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -31,6 +31,31 @@ tap.test('pool expands only to max limit', (t) => {
     .catch(t.threw);
 });
 
+tap.test('pool expands to min', (t) => {
+  const resourceFactory = new ResourceFactory();
+
+  const factory = {
+    name: 'test1',
+    create: resourceFactory.create.bind(resourceFactory),
+    destroy: resourceFactory.destroy.bind(resourceFactory),
+    validate: resourceFactory.validate.bind(resourceFactory),
+    max: 3,
+    min: 2,
+    idleTimeoutMillis: 100,
+    acquireTimeoutMillis: 100,
+  };
+
+  const pool = new Pool(factory);
+
+  pool
+    .acquire()
+    .then((client) => {
+      t.equal(2, pool.using);
+      t.end();
+    })
+    .catch(t.threw);
+});
+
 tap.test('pool uses LIFO', (t) => {
   const resourceFactory = new ResourceFactory();
 


### PR DESCRIPTION
Attempts to fix https://github.com/sequelize/sequelize-pool/issues/22 by acquiring up to the min connections.

I suspect I need to add handlers to make sure it doesn't dispose of the min connections, but not sure.  Also unsure if this is the right way to resolve the issue. Wanted to get the conversation started via the PR.