### PR TITLE
feat: tsconfig: target node >= 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -203,9 +203,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "version": "10.17.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+      "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -4248,9 +4248,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "types": "types",
   "dependencies": {},
   "devDependencies": {
-    "@types/node": "^14.0.1",
+    "@types/node": "^10.17.54",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.0.0",
     "eslint": "^7.0.0",
@@ -31,7 +31,7 @@
     "tap": "^14.10.7",
     "typedoc": "^0.20.16",
     "typedoc-plugin-markdown": "^3.4.2",
-    "typescript": "^4.0.0"
+    "typescript": "~4.2.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES6",
+    "target": "es2018",
+    "lib": ["es2018"],
     "allowJs": false,
     "declaration": true,
     "declarationDir": "types",


### PR DESCRIPTION
The current target (es6) doesn't support async/await, so typescript
polyfills it for us, with a weird mess of __awaiter and yield. If
we target node >= 8, the compiler just emits the async/await code
we wrote, which leads to happier monitoring tools.

sequelize 6 supports node >= 10, and sequelize 5 pins an older version
of this library. We already declare engines >= 10 in package.json.

Pin typescript version to 4.2 (they don't do semver).

c.f. https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-10


`lib/Pool.js` before:
```
    destroyAllNow() {
        return __awaiter(this, void 0, void 0, function* () {
...
            for (const resource of resources) {
                try {
                    yield this.destroy(resource);
                }
```

After:
```
    async destroyAllNow() {
...
        for (const resource of resources) {
            try {
                await this.destroy(resource);
            }
```