### PR TITLE
Fix acquire not resolving after destroying available resources

### DIFF
--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -538,6 +538,14 @@ export class Pool<RawResource> {
       await this._factory.destroy(resource);
     } finally {
       this._ensureMinimum();
+      // Since we are removing the resource, we need to go ahead and
+      // call _dispense() in order to ensure the resource is replaced (if appropriate)
+      // and any pending resource requests are fulfilled.
+      if (!this._draining) {
+        process.nextTick(() => {
+          this._dispense();
+        });
+      }
     }
   }
 

--- a/test/integration/pool-test.js
+++ b/test/integration/pool-test.js
@@ -598,3 +598,29 @@ tap.test('pool does not leak expired resources to pending requests', (t) => {
     pool.release(clientA);
   });
 });
+
+tap.test('acquire resolves after destroying the available resources', (t) => {
+  const resourceFactory = new ResourceFactory();
+
+  const factory = {
+    name: 'test22',
+    create: resourceFactory.create.bind(resourceFactory),
+    destroy: resourceFactory.destroy.bind(resourceFactory),
+    validate: resourceFactory.validate.bind(resourceFactory),
+    max: 1,
+    min: 0,
+    idleTimeoutMillis: 100,
+    acquireTimeoutMillis: 100,
+  };
+
+  const pool = new Pool(factory);
+
+  pool.acquire().then((resource1) => {
+    pool.acquire().then((resource2) => {
+      pool.release(resource2);
+
+      t.end();
+    });
+    pool.destroy(resource1);
+  });
+});


### PR DESCRIPTION
We're hitting an issue in sequelize when using postgres's `idle_in_transaction_session_timeout`. 
When the code inside a transaction hits the timeout it causes the connection to be destroyed due to a protocol error and waiting connections throw a `ConnectionAcquireTimeoutError` after 60s (the default `acquireTimeoutMillis` in sequelize).

It's easily reproducible using `pool.max: 1` and:

```js
await Promise.allSettled([
  sequelize.transaction(async transaction => { 
    await sequelize.query('SET LOCAL idle_in_transaction_session_timeout = 50', { transaction }); 
    await new Promise(resolve => setTimeout(resolve, 100)); 
    await sequelize.query('SELECT 1', { transaction }); 
  }), 
  sequelize.query('SELECT 1')
]);
```

Resolves to:
```js
[
  {
    reason: DatabaseError [SequelizeDatabaseError]: Client has encountered a connection error and is not queryable
    ...
    status: 'rejected'
  },
  {
    reason: ConnectionAcquireTimeoutError 
    ...
    status: 'rejected'
  }
]
```

Expected behaviour would be for the second query to be fulfilled.